### PR TITLE
Document missing NRIA_* installation env vars

### DIFF
--- a/src/content/docs/infrastructure/infrastructure-agent/configuration/infrastructure-agent-configuration-settings.mdx
+++ b/src/content/docs/infrastructure/infrastructure-agent/configuration/infrastructure-agent-configuration-settings.mdx
@@ -1695,6 +1695,244 @@ Metrics can also be enriched with extended cloud metadata (including custom reso
       </tbody>
     </table>
   </Collapser>
+
+  <Collapser
+    className="freq-link"
+    id="safe-bin-dir"
+    title="safe_bin_dir"
+  >
+    Directory where the agent expects to find executables for integrations.
+
+    <table>
+      <thead>
+        <tr>
+          <th style={{ width: "200px" }}>
+            YML option name
+          </th>
+
+          <th style={{ width: "200px" }}>
+            Environment variable
+          </th>
+
+          <th>
+            Type
+          </th>
+
+          <th>
+            Default
+          </th>
+
+          <th>
+            Version
+          </th>
+        </tr>
+      </thead>
+
+      <tbody>
+        <tr>
+          <td>
+            `safe_bin_dir`
+          </td>
+
+          <td>
+            `NRIA_SAFE_BIN_DIR`
+          </td>
+
+          <td>
+            string
+          </td>
+
+          <td>
+            Linux: `/opt/newrelic-infra`
+
+            Windows: `C:\Program Files\NewRelic\newrelic-infra\`
+          </td>
+
+          <td>
+            1.48.0
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </Collapser>
+
+  <Collapser
+    className="freq-link"
+    id="agent-temp-dir"
+    title="agent_temp_dir"
+  >
+    Directory where the agent stores temporary files (for example, log forwarder configuration and integration discovery data). This directory is deleted on every agent restart, but only if it still matches its default value.
+
+    <table>
+      <thead>
+        <tr>
+          <th style={{ width: "200px" }}>
+            YML option name
+          </th>
+
+          <th style={{ width: "200px" }}>
+            Environment variable
+          </th>
+
+          <th>
+            Type
+          </th>
+
+          <th>
+            Default
+          </th>
+
+          <th>
+            Version
+          </th>
+        </tr>
+      </thead>
+
+      <tbody>
+        <tr>
+          <td>
+            `agent_temp_dir`
+          </td>
+
+          <td>
+            `NRIA_AGENT_TEMP_DIR`
+          </td>
+
+          <td>
+            string
+          </td>
+
+          <td>
+            Linux: `/var/db/newrelic-infra/tmp`
+
+            Windows: `C:\ProgramData\New Relic\newrelic-infra\tmp`
+          </td>
+
+          <td>
+            1.39.0
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </Collapser>
+
+  <Collapser
+    className="freq-link"
+    id="logging-configs-dir"
+    title="logging_configs_dir"
+  >
+    Directory containing configuration files for the log forwarder.
+
+    <table>
+      <thead>
+        <tr>
+          <th style={{ width: "200px" }}>
+            YML option name
+          </th>
+
+          <th style={{ width: "200px" }}>
+            Environment variable
+          </th>
+
+          <th>
+            Type
+          </th>
+
+          <th>
+            Default
+          </th>
+
+          <th>
+            Version
+          </th>
+        </tr>
+      </thead>
+
+      <tbody>
+        <tr>
+          <td>
+            `logging_configs_dir`
+          </td>
+
+          <td>
+            `NRIA_LOGGING_CONFIGS_DIR`
+          </td>
+
+          <td>
+            string
+          </td>
+
+          <td>
+            `/etc/newrelic-infra/logging.d`
+          </td>
+
+          <td>
+            1.0.2
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </Collapser>
+
+  <Collapser
+    className="freq-link"
+    id="logging-home-dir"
+    title="logging_home_dir"
+  >
+    Directory containing the log forwarder's binaries and other required files.
+
+    <table>
+      <thead>
+        <tr>
+          <th style={{ width: "200px" }}>
+            YML option name
+          </th>
+
+          <th style={{ width: "200px" }}>
+            Environment variable
+          </th>
+
+          <th>
+            Type
+          </th>
+
+          <th>
+            Default
+          </th>
+
+          <th>
+            Version
+          </th>
+        </tr>
+      </thead>
+
+      <tbody>
+        <tr>
+          <td>
+            `logging_home_dir`
+          </td>
+
+          <td>
+            `NRIA_LOGGING_HOME_DIR`
+          </td>
+
+          <td>
+            string
+          </td>
+
+          <td>
+            Linux: `/var/db/newrelic-infra/newrelic-integrations/logging/`
+
+            Windows: `C:\Program Files\New Relic\newrelic-infra\newrelic-integrations\logging\`
+          </td>
+
+          <td>
+            1.0.2
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </Collapser>
 </CollapserGroup>
 
 ## Integrations variables


### PR DESCRIPTION
## Summary
- Adds 4 `NRIA_*` env vars to the Installation variables section that were missing from this page: `NRIA_SAFE_BIN_DIR`, `NRIA_AGENT_TEMP_DIR`, `NRIA_LOGGING_CONFIGS_DIR`, `NRIA_LOGGING_HOME_DIR`.
- These are set by Agent Control for configuring infra-agent
