### PR TITLE
Document logging_bin_dir installation env var

### DIFF
--- a/src/content/docs/infrastructure/infrastructure-agent/configuration/infrastructure-agent-configuration-settings.mdx
+++ b/src/content/docs/infrastructure/infrastructure-agent/configuration/infrastructure-agent-configuration-settings.mdx
@@ -1933,6 +1933,64 @@ Metrics can also be enriched with extended cloud metadata (including custom reso
       </tbody>
     </table>
   </Collapser>
+
+  <Collapser
+    className="freq-link"
+    id="logging-bin-dir"
+    title="logging_bin_dir"
+  >
+    Directory containing binaries for the log forwarder.
+
+    <table>
+      <thead>
+        <tr>
+          <th style={{ width: "200px" }}>
+            YML option name
+          </th>
+
+          <th style={{ width: "200px" }}>
+            Environment variable
+          </th>
+
+          <th>
+            Type
+          </th>
+
+          <th>
+            Default
+          </th>
+
+          <th>
+            Version
+          </th>
+        </tr>
+      </thead>
+
+      <tbody>
+        <tr>
+          <td>
+            `logging_bin_dir`
+          </td>
+
+          <td>
+            `NRIA_LOGGING_BIN_DIR`
+          </td>
+
+          <td>
+            string
+          </td>
+
+          <td>
+            `/var/db/newrelic-infra/newrelic-integrations/logging/`
+          </td>
+
+          <td>
+            1.0.2
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </Collapser>
 </CollapserGroup>
 
 ## Integrations variables


### PR DESCRIPTION
## Summary
- Adds `NRIA_LOGGING_BIN_DIR` to the Installation variables section as AC uses it in [windows config](https://github.com/newrelic/newrelic-agent-control/blob/51e0e9ecebdad48ef9e7906d45243e535d015a07/agent-control/agent-type-registry/newrelic/host-windows-com.newrelic.infrastructure-0.1.0.yaml#L130)
